### PR TITLE
EasyCAT Organization

### DIFF
--- a/src/main/java/us/ihmc/etherCAT/examples/EasyCATExample.java
+++ b/src/main/java/us/ihmc/etherCAT/examples/EasyCATExample.java
@@ -16,7 +16,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 
 import us.ihmc.etherCAT.master.EtherCATRealtimeThread;
-import us.ihmc.etherCAT.slaves.EasyCATSlave;
+import us.ihmc.etherCAT.slaves.easyCAT.EasyCATSlave32;
 import us.ihmc.realtime.MonotonicTime;
 import us.ihmc.realtime.PriorityParameters;
 
@@ -38,8 +38,8 @@ import us.ihmc.realtime.PriorityParameters;
  */
 public class EasyCATExample extends EtherCATRealtimeThread {
 
-	private final EasyCATSlave wirelessButtonsSlave = new EasyCATSlave(0, 0);
-	private final EasyCATSlave encoderSlave = new EasyCATSlave(0, 1);
+	private final EasyCATSlave32 wirelessButtonsSlave = new EasyCATSlave32(0, 0);
+	private final EasyCATSlave32 encoderSlave = new EasyCATSlave32(0, 1);
 
 	private JLabel button1Label;
 	private JLabel button2Label;

--- a/src/main/java/us/ihmc/etherCAT/examples/EasyCatTwoLoadCellsExample.java
+++ b/src/main/java/us/ihmc/etherCAT/examples/EasyCatTwoLoadCellsExample.java
@@ -17,7 +17,6 @@ import javax.swing.JPanel;
 
 import us.ihmc.etherCAT.master.EtherCATRealtimeThread;
 import us.ihmc.etherCAT.slaves.EasyCATLoadCellSlave;
-import us.ihmc.etherCAT.slaves.EasyCATSlave;
 import us.ihmc.realtime.MonotonicTime;
 import us.ihmc.realtime.PriorityParameters;
 

--- a/src/main/java/us/ihmc/etherCAT/slaves/EasyCATActuatorLowerJoint.java
+++ b/src/main/java/us/ihmc/etherCAT/slaves/EasyCATActuatorLowerJoint.java
@@ -1,10 +1,10 @@
 package us.ihmc.etherCAT.slaves;
 
-import us.ihmc.etherCAT.slaves.EasyCATSlave;
+import us.ihmc.etherCAT.slaves.easyCAT.EasyCATSlave32;
 
 import java.io.IOException;
 
-public class EasyCATActuatorLowerJoint extends EasyCATSlave
+public class EasyCATActuatorLowerJoint extends EasyCATSlave32
 {
    protected int[] frameData = new int[32];
    protected int currentRotationRaw1 = 0;

--- a/src/main/java/us/ihmc/etherCAT/slaves/EasyCATLoadCellSlave.java
+++ b/src/main/java/us/ihmc/etherCAT/slaves/EasyCATLoadCellSlave.java
@@ -1,10 +1,10 @@
 package us.ihmc.etherCAT.slaves;
 
-import us.ihmc.etherCAT.slaves.EasyCATSlave;
+import us.ihmc.etherCAT.slaves.easyCAT.EasyCATSlave32;
 
 import java.io.IOException;
 
-public class EasyCATLoadCellSlave extends EasyCATSlave {
+public class EasyCATLoadCellSlave extends EasyCATSlave32 {
 
 	private int[] loadCellRawValues = new int[4];
 	private int[] loadCellProcessedValues = new int[4];

--- a/src/main/java/us/ihmc/etherCAT/slaves/EasyCATVerticalPositionerSlave.java
+++ b/src/main/java/us/ihmc/etherCAT/slaves/EasyCATVerticalPositionerSlave.java
@@ -1,10 +1,10 @@
 package us.ihmc.etherCAT.slaves;
 
-import us.ihmc.etherCAT.slaves.EasyCATSlave;
+import us.ihmc.etherCAT.slaves.easyCAT.EasyCATSlave32;
 
 import java.io.IOException;
 
-public class EasyCATVerticalPositionerSlave extends EasyCATSlave
+public class EasyCATVerticalPositionerSlave extends EasyCATSlave32
 {
 
    protected int[] frameData = new int[32];

--- a/src/main/java/us/ihmc/etherCAT/slaves/EasyCATWirelessButtonsSlave.java
+++ b/src/main/java/us/ihmc/etherCAT/slaves/EasyCATWirelessButtonsSlave.java
@@ -1,12 +1,11 @@
 package us.ihmc.etherCAT.slaves;
 
-import us.ihmc.etherCAT.slaves.EasyCATSlave;
+import us.ihmc.etherCAT.slaves.easyCAT.EasyCATSlave32;
 
 import java.io.IOException;
 
-public class EasyCATWirelessButtonsSlave extends EasyCATSlave
+public class EasyCATWirelessButtonsSlave extends EasyCATSlave32
 {
-
    private int[] frameData = new int[32];
    private boolean[] buttonStates = new boolean[4];
    private int dataFlipBit = 0;

--- a/src/main/java/us/ihmc/etherCAT/slaves/easyCAT/EasyCATSlave.java
+++ b/src/main/java/us/ihmc/etherCAT/slaves/easyCAT/EasyCATSlave.java
@@ -1,4 +1,4 @@
-package us.ihmc.etherCAT.slaves;
+package us.ihmc.etherCAT.slaves.easyCAT;
 
 import java.io.IOException;
 
@@ -13,41 +13,43 @@ import us.ihmc.etherCAT.master.TxPDO;
  */
 public class EasyCATSlave extends Slave
 {
-
-   static final int vendorID = 0x0000079a;
-   static final int productCode = 0x00defede;
-
-   private static final int LENGTH = 32;
-
+   protected int easyCATSlaveFrameLength;
+   
    private class RPDO_1600 extends RxPDO
    {
 
-      private final Unsigned8[] data = array(new Unsigned8[LENGTH]);
+      private final Unsigned8[] data;
 
       protected RPDO_1600()
       {
          super(0x1600);
+         data = array(new Unsigned8[easyCATSlaveFrameLength]);
       }
    }
 
    private class TPDO_1a00 extends TxPDO
    {
-      private final Unsigned8[] data = array(new Unsigned8[LENGTH]);
+      private final Unsigned8[] data;
 
       protected TPDO_1a00()
       {
          super(0x1A00);
+         data  = array(new Unsigned8[easyCATSlaveFrameLength]);
       }
    }
 
    //receive and transmit PDOs
-   private final RPDO_1600 RPDO_x1600 = new RPDO_1600();
-   private final TPDO_1a00 TPDO_x1A00 = new TPDO_1a00();
+   private final RPDO_1600 RPDO_x1600;
+   private final TPDO_1a00 TPDO_x1A00;
 
-   public EasyCATSlave(int alias, int ringPosition) throws IOException
+   public EasyCATSlave(long vendorID, long productCode, int easyCATSlaveFrameLength, int alias, int ringPosition) throws IOException
    {
       super(vendorID, productCode, alias, ringPosition);
+      this.easyCATSlaveFrameLength = easyCATSlaveFrameLength;
 
+      RPDO_x1600 = new RPDO_1600();
+      TPDO_x1A00 = new TPDO_1a00();
+      
       registerSyncManager(new SyncManager(0, true));
       registerSyncManager(new SyncManager(1, true));
       
@@ -58,7 +60,7 @@ public class EasyCATSlave extends Slave
    //get desired TxPDOEntry values
    public void getTransmitBytes(int[] arrayToPack, int startIndex, int endIndex) //new method. should replace getTransmitBytes(int startIndex, int endIndex)
    {
-      if ((startIndex < 0) || (endIndex > (LENGTH - 1)) || (startIndex > endIndex) || ((endIndex - startIndex) + 1 != arrayToPack.length))
+      if ((startIndex < 0) || (endIndex > (easyCATSlaveFrameLength - 1)) || (startIndex > endIndex) || ((endIndex - startIndex) + 1 != arrayToPack.length))
       {
          throw new RuntimeException("Invalid method parameters");
       }
@@ -71,7 +73,7 @@ public class EasyCATSlave extends Slave
    //set first values.length number of RxPDOEntry values
    public void setReceiveBytes(int[] values)
    {
-      if ((values == null) || (values.length > LENGTH))
+      if ((values == null) || (values.length > easyCATSlaveFrameLength))
       {
          throw new RuntimeException("invalid argument dimensions. Must be between 1 and 32");
       }

--- a/src/main/java/us/ihmc/etherCAT/slaves/easyCAT/EasyCATSlave128.java
+++ b/src/main/java/us/ihmc/etherCAT/slaves/easyCAT/EasyCATSlave128.java
@@ -1,0 +1,15 @@
+package us.ihmc.etherCAT.slaves.easyCAT;
+
+import java.io.IOException;
+
+public class EasyCATSlave128 extends EasyCATSlave
+{
+	static final long vendorID = 0x0000079a;
+	static final long productCode = 0xDEFED128L;
+	static final int easyCATSlave128FrameLength = 128;
+	public EasyCATSlave128(int alias, int ringPosition) throws IOException
+	{
+		super(vendorID, productCode, easyCATSlave128FrameLength, alias, ringPosition);
+	}
+	
+}

--- a/src/main/java/us/ihmc/etherCAT/slaves/easyCAT/EasyCATSlave16.java
+++ b/src/main/java/us/ihmc/etherCAT/slaves/easyCAT/EasyCATSlave16.java
@@ -1,0 +1,15 @@
+package us.ihmc.etherCAT.slaves.easyCAT;
+
+import java.io.IOException;
+
+public class EasyCATSlave16 extends EasyCATSlave
+{
+	static final long vendorID = 0x0000079a;
+	static final long productCode = 0xDEFEDE16L;
+	static final int easyCATSlave16FrameLength = 16;
+	public EasyCATSlave16(int alias, int ringPosition) throws IOException
+	{
+		super(vendorID, productCode, easyCATSlave16FrameLength, alias, ringPosition);
+	}
+	
+}

--- a/src/main/java/us/ihmc/etherCAT/slaves/easyCAT/EasyCATSlave32.java
+++ b/src/main/java/us/ihmc/etherCAT/slaves/easyCAT/EasyCATSlave32.java
@@ -1,0 +1,15 @@
+package us.ihmc.etherCAT.slaves.easyCAT;
+
+import java.io.IOException;
+
+public class EasyCATSlave32 extends EasyCATSlave
+{
+	static final long vendorID = 0x0000079a;
+	static final long productCode = 0x00DEFEDEL;
+	static final int easyCATSlave32FrameLength = 32;
+	public EasyCATSlave32(int alias, int ringPosition) throws IOException
+	{
+		super(vendorID, productCode, easyCATSlave32FrameLength, alias, ringPosition);
+	}
+	
+}

--- a/src/main/java/us/ihmc/etherCAT/slaves/easyCAT/EasyCATSlave64.java
+++ b/src/main/java/us/ihmc/etherCAT/slaves/easyCAT/EasyCATSlave64.java
@@ -1,0 +1,15 @@
+package us.ihmc.etherCAT.slaves.easyCAT;
+
+import java.io.IOException;
+
+public class EasyCATSlave64 extends EasyCATSlave
+{
+	static final long vendorID = 0x0000079a;
+	static final long productCode = 0xDEFEDE64L;
+	static final int easyCATSlave64FrameLength = 64;
+	public EasyCATSlave64(int alias, int ringPosition) throws IOException
+	{
+		super(vendorID, productCode, easyCATSlave64FrameLength, alias, ringPosition);
+	}
+	
+}


### PR DESCRIPTION
* Aimed to make the EasyCATSlave class a little more organized
* There is now an EasyCATSlave base class that can take a specified length, vendor ID, and product code
    * This makes users less likely to make a copy of the EasyCATSlave for their specific project and is thus cleaner from an implementation standpoint
* Added the four default EasyCAT slave configurations provided by the [AB&T EasyCAT configure tool](https://www.bausano.net/images/arduino-easycat/EasyConfigurator_UserManual.pdf)
* Updated IHMC EasyCATSlave examples to support the change