### PR TITLE
More verbose output for offline and unconfigured slaves

### DIFF
--- a/src/main/java/us/ihmc/etherCAT/master/Master.java
+++ b/src/main/java/us/ihmc/etherCAT/master/Master.java
@@ -387,7 +387,7 @@ public class Master implements MasterInterface
             throw new SlavesOfflineException(slavecount, registeredSlaves.size(), offlineSlaves, this);
          }
 
-         if(unconfiguredSlaves.isEmpty())
+         if(!unconfiguredSlaves.isEmpty())
          {
             throw new SlavesNotConfiguredException(slavecount, registeredSlaves.size(), unconfiguredSlaves, this);
          }

--- a/src/main/java/us/ihmc/etherCAT/master/Master.java
+++ b/src/main/java/us/ihmc/etherCAT/master/Master.java
@@ -1,13 +1,8 @@
 package us.ihmc.etherCAT.master;
 
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import us.ihmc.etherCAT.master.EtherCATStatusCallback.TRACE_EVENT;
+import us.ihmc.etherCAT.master.exception.SlavesNotConfiguredException;
+import us.ihmc.etherCAT.master.exception.SlavesOfflineException;
 import us.ihmc.soem.generated.ec_slavet;
 import us.ihmc.soem.generated.ec_smt;
 import us.ihmc.soem.generated.ec_state;
@@ -16,6 +11,13 @@ import us.ihmc.soem.generated.ecx_portt;
 import us.ihmc.soem.generated.soem;
 import us.ihmc.soem.generated.soemConstants;
 import us.ihmc.tools.nativelibraries.NativeLibraryLoader;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * 
@@ -197,8 +199,12 @@ public class Master implements MasterInterface
    {
       this.requireAllSlaves = requireAllSlaves;
    }
-   
-   
+
+   public boolean isRequireAllSlaves()
+   {
+      return requireAllSlaves;
+   }
+
    /**
     * Calculate the process data size for a slave.
     * 
@@ -298,29 +304,16 @@ public class Master implements MasterInterface
       getEtherCATStatusCallback().trace(TRACE_EVENT.CONFIGURING_SLAVES);
       int slavecount = soem.ecx_slavecount(context);
       
-      if(requireAllSlaves)
-      {
-         if(registeredSlaves.size() != slavecount)
-         {
-            if(registeredSlaves.size() < slavecount)
-            {
-               throw new IOException("Not all registeredSlaves are configured and requireAllSlaves is true, got " + slavecount + " registeredSlaves, expected " + registeredSlaves.size());
-            }
-            else
-            {
-               throw new IOException("Not all registeredSlaves are online and requireAllSlaves is true, got " + slavecount + " registeredSlaves, expected " + registeredSlaves.size());
-            }
-         }
-      }
-      
-      
       getEtherCATStatusCallback().trace(TRACE_EVENT.WAIT_FOR_PREOP);
       
       if(soem.ecx_statecheck(context, 0, ec_state.EC_STATE_PRE_OP.swigValue(), soemConstants.EC_TIMEOUTSTATE) == 0)
       {
          throw new IOException("Cannot transfer to PREOP state");
       }
-      
+
+      List<Slave> offlineSlaves = new ArrayList<>();
+      List<Slave> unconfiguredSlaves = new ArrayList<>();
+
       slaveMap = new Slave[slavecount];
       int processDataSize = 0;
       
@@ -345,7 +338,6 @@ public class Master implements MasterInterface
          
          Slave slave = getSlave(alias, position);
          
-         
          if(slave != null)
          {
             if(slave.getVendor() != ec_slave.getEep_man() || slave.getProductCode() != ec_slave.getEep_id())
@@ -358,17 +350,11 @@ public class Master implements MasterInterface
          }
          else
          {
-            if(requireAllSlaves)
-            {
-               throw new IOException("Unconfigured slave on alias " + alias + ":" + position + ". Make sure to power cycle after changing alias addresses.");
-            }
-            else
-            {
-               slave = new UnconfiguredSlave(ec_slave.getName(), (int)ec_slave.getEep_man(), (int)ec_slave.getEep_id(), alias, position);
-               slave.configure(this, getContext(), port, ec_slave, i + 1, false, cycleTimeInNs);
-               slaveMap[i] = slave;
-               etherCATStatusCallback.notifyUnconfiguredSlave(slaveMap[i]);
-            }
+            slave = new UnconfiguredSlave(ec_slave.getName(), (int)ec_slave.getEep_man(), (int)ec_slave.getEep_id(), alias, position);
+            slave.configure(this, getContext(), port, ec_slave, i + 1, false, cycleTimeInNs);
+            slaveMap[i] = slave;
+            etherCATStatusCallback.notifyUnconfiguredSlave(slaveMap[i]);
+            unconfiguredSlaves.add(slave);
          }
          
          // Disable Complete Access reading of SDO configuration.
@@ -384,11 +370,32 @@ public class Master implements MasterInterface
          previousPosition = position;
          
       }
+
       for(int i = 0; i < registeredSlaves.size(); i++)
       {
          if(!registeredSlaves.get(i).isConfigured())
          {
             etherCATStatusCallback.notifySlaveNotFound(registeredSlaves.get(i));
+            offlineSlaves.add(registeredSlaves.get(i));
+         }
+      }
+
+      if(requireAllSlaves)
+      {
+         if(!offlineSlaves.isEmpty())
+         {
+            throw new SlavesOfflineException(slavecount, registeredSlaves.size(), offlineSlaves, this);
+         }
+
+         if(unconfiguredSlaves.isEmpty())
+         {
+            throw new SlavesNotConfiguredException(slavecount, registeredSlaves.size(), unconfiguredSlaves, this);
+         }
+
+         if(slavecount != registeredSlaves.size())
+         {
+            throw new IOException(
+                  "Unexpected slave count mismatch (requireAllSlaves is true). [" + slavecount + " / " + registeredSlaves.size() + "] slaves online.");
          }
       }
 

--- a/src/main/java/us/ihmc/etherCAT/master/exception/SlaveCountException.java
+++ b/src/main/java/us/ihmc/etherCAT/master/exception/SlaveCountException.java
@@ -4,16 +4,16 @@ import us.ihmc.etherCAT.master.Master;
 import us.ihmc.etherCAT.master.Slave;
 
 import java.io.IOException;
-import java.util.Collection;
+import java.util.List;
 
 public abstract class SlaveCountException extends IOException
 {
    private final int currentSlaveCount;
    private final int registeredSlaveCount;
-   private final Collection<Slave> slaves;
+   private final List<Slave> slaves;
    protected final Master master;
 
-   public SlaveCountException(int currentSlaveCount, int registeredSlaveCount, Collection<Slave> slaves, Master master)
+   public SlaveCountException(int currentSlaveCount, int registeredSlaveCount, List<Slave> slaves, Master master)
    {
       this.currentSlaveCount = currentSlaveCount;
       this.registeredSlaveCount = registeredSlaveCount;
@@ -33,7 +33,7 @@ public abstract class SlaveCountException extends IOException
       return registeredSlaveCount;
    }
 
-   public Collection<Slave> getSlaves()
+   public List<Slave> getSlaves()
    {
       return slaves;
    }

--- a/src/main/java/us/ihmc/etherCAT/master/exception/SlaveCountException.java
+++ b/src/main/java/us/ihmc/etherCAT/master/exception/SlaveCountException.java
@@ -1,0 +1,40 @@
+package us.ihmc.etherCAT.master.exception;
+
+import us.ihmc.etherCAT.master.Master;
+import us.ihmc.etherCAT.master.Slave;
+
+import java.io.IOException;
+import java.util.Collection;
+
+public abstract class SlaveCountException extends IOException
+{
+   private final int currentSlaveCount;
+   private final int registeredSlaveCount;
+   private final Collection<Slave> slaves;
+   protected final Master master;
+
+   public SlaveCountException(int currentSlaveCount, int registeredSlaveCount, Collection<Slave> slaves, Master master)
+   {
+      this.currentSlaveCount = currentSlaveCount;
+      this.registeredSlaveCount = registeredSlaveCount;
+      this.slaves = slaves;
+      this.master = master;
+   }
+
+   public abstract String getMessage();
+
+   public int getCurrentSlaveCount()
+   {
+      return currentSlaveCount;
+   }
+
+   public int getRegisteredSlaveCount()
+   {
+      return registeredSlaveCount;
+   }
+
+   public Collection<Slave> getSlaves()
+   {
+      return slaves;
+   }
+}

--- a/src/main/java/us/ihmc/etherCAT/master/exception/SlavesNotConfiguredException.java
+++ b/src/main/java/us/ihmc/etherCAT/master/exception/SlavesNotConfiguredException.java
@@ -19,6 +19,6 @@ public class SlavesNotConfiguredException extends SlaveCountException
       String slavesListString = StringUtils.join(getSlaves(), ",");
 
       return "Not all slaves are configured" + (master.isRequireAllSlaves() ? " and requireAllSlaves is true" : "") + ".\n[" + getCurrentSlaveCount()
-             + " / " + getRegisteredSlaveCount() + " slaves online.\nInvalid slaves: [" + slavesListString + "]";
+             + " / " + getRegisteredSlaveCount() + "] slaves online.\nInvalid slaves: [" + slavesListString + "]";
    }
 }

--- a/src/main/java/us/ihmc/etherCAT/master/exception/SlavesNotConfiguredException.java
+++ b/src/main/java/us/ihmc/etherCAT/master/exception/SlavesNotConfiguredException.java
@@ -1,0 +1,28 @@
+package us.ihmc.etherCAT.master.exception;
+
+import us.ihmc.etherCAT.master.Master;
+import us.ihmc.etherCAT.master.Slave;
+
+import java.util.Collection;
+
+public class SlavesNotConfiguredException extends SlaveCountException
+{
+   public SlavesNotConfiguredException(int currentSlaveCount, int registeredSlaveCount, Collection<Slave> slaves, Master master)
+   {
+      super(currentSlaveCount, registeredSlaveCount, slaves, master);
+   }
+
+   @Override
+   public String getMessage()
+   {
+      StringBuilder slaveStringBuilder = new StringBuilder();
+
+      for (Slave slave : getSlaves())
+      {
+         slaveStringBuilder.append(slave.toString()).append(", ");
+      }
+
+      return "Not all slaves are configured" + (master.isRequireAllSlaves() ? " and requireAllSlaves is true" : "") + ".\n[" + getCurrentSlaveCount()
+             + " / " + getRegisteredSlaveCount() + " slaves online.\nInvalid slaves: [" + slaveStringBuilder + "]";
+   }
+}

--- a/src/main/java/us/ihmc/etherCAT/master/exception/SlavesNotConfiguredException.java
+++ b/src/main/java/us/ihmc/etherCAT/master/exception/SlavesNotConfiguredException.java
@@ -1,13 +1,14 @@
 package us.ihmc.etherCAT.master.exception;
 
+import org.apache.commons.lang3.StringUtils;
 import us.ihmc.etherCAT.master.Master;
 import us.ihmc.etherCAT.master.Slave;
 
-import java.util.Collection;
+import java.util.List;
 
 public class SlavesNotConfiguredException extends SlaveCountException
 {
-   public SlavesNotConfiguredException(int currentSlaveCount, int registeredSlaveCount, Collection<Slave> slaves, Master master)
+   public SlavesNotConfiguredException(int currentSlaveCount, int registeredSlaveCount, List<Slave> slaves, Master master)
    {
       super(currentSlaveCount, registeredSlaveCount, slaves, master);
    }
@@ -15,14 +16,9 @@ public class SlavesNotConfiguredException extends SlaveCountException
    @Override
    public String getMessage()
    {
-      StringBuilder slaveStringBuilder = new StringBuilder();
-
-      for (Slave slave : getSlaves())
-      {
-         slaveStringBuilder.append(slave.toString()).append(", ");
-      }
+      String slavesListString = StringUtils.join(getSlaves(), ",");
 
       return "Not all slaves are configured" + (master.isRequireAllSlaves() ? " and requireAllSlaves is true" : "") + ".\n[" + getCurrentSlaveCount()
-             + " / " + getRegisteredSlaveCount() + " slaves online.\nInvalid slaves: [" + slaveStringBuilder + "]";
+             + " / " + getRegisteredSlaveCount() + " slaves online.\nInvalid slaves: [" + slavesListString + "]";
    }
 }

--- a/src/main/java/us/ihmc/etherCAT/master/exception/SlavesOfflineException.java
+++ b/src/main/java/us/ihmc/etherCAT/master/exception/SlavesOfflineException.java
@@ -1,0 +1,28 @@
+package us.ihmc.etherCAT.master.exception;
+
+import us.ihmc.etherCAT.master.Master;
+import us.ihmc.etherCAT.master.Slave;
+
+import java.util.Collection;
+
+public class SlavesOfflineException extends SlaveCountException
+{
+   public SlavesOfflineException(int currentSlaveCount, int registeredSlaveCount, Collection<Slave> slaves, Master master)
+   {
+      super(currentSlaveCount, registeredSlaveCount, slaves, master);
+   }
+
+   @Override
+   public String getMessage()
+   {
+      StringBuilder slaveStringBuilder = new StringBuilder();
+
+      for (Slave slave : getSlaves())
+      {
+         slaveStringBuilder.append(slave.toString()).append(", ");
+      }
+
+      return "Not all registeredSlaves are online" + (master.isRequireAllSlaves() ? " and requireAllSlaves is true" : "") + ".\n[" + getCurrentSlaveCount()
+             + " / " + getRegisteredSlaveCount() + " slaves online.\nOffline slaves: [" + slaveStringBuilder + "]";
+   }
+}

--- a/src/main/java/us/ihmc/etherCAT/master/exception/SlavesOfflineException.java
+++ b/src/main/java/us/ihmc/etherCAT/master/exception/SlavesOfflineException.java
@@ -1,13 +1,14 @@
 package us.ihmc.etherCAT.master.exception;
 
+import org.apache.commons.lang3.StringUtils;
 import us.ihmc.etherCAT.master.Master;
 import us.ihmc.etherCAT.master.Slave;
 
-import java.util.Collection;
+import java.util.List;
 
 public class SlavesOfflineException extends SlaveCountException
 {
-   public SlavesOfflineException(int currentSlaveCount, int registeredSlaveCount, Collection<Slave> slaves, Master master)
+   public SlavesOfflineException(int currentSlaveCount, int registeredSlaveCount, List<Slave> slaves, Master master)
    {
       super(currentSlaveCount, registeredSlaveCount, slaves, master);
    }
@@ -15,14 +16,9 @@ public class SlavesOfflineException extends SlaveCountException
    @Override
    public String getMessage()
    {
-      StringBuilder slaveStringBuilder = new StringBuilder();
-
-      for (Slave slave : getSlaves())
-      {
-         slaveStringBuilder.append(slave.toString()).append(", ");
-      }
+      String slavesListString = StringUtils.join(getSlaves(), ",");
 
       return "Not all registeredSlaves are online" + (master.isRequireAllSlaves() ? " and requireAllSlaves is true" : "") + ".\n[" + getCurrentSlaveCount()
-             + " / " + getRegisteredSlaveCount() + " slaves online.\nOffline slaves: [" + slaveStringBuilder + "]";
+             + " / " + getRegisteredSlaveCount() + " slaves online.\nOffline slaves: [" + slavesListString + "]";
    }
 }

--- a/src/main/java/us/ihmc/etherCAT/master/exception/SlavesOfflineException.java
+++ b/src/main/java/us/ihmc/etherCAT/master/exception/SlavesOfflineException.java
@@ -19,6 +19,6 @@ public class SlavesOfflineException extends SlaveCountException
       String slavesListString = StringUtils.join(getSlaves(), ",");
 
       return "Not all registeredSlaves are online" + (master.isRequireAllSlaves() ? " and requireAllSlaves is true" : "") + ".\n[" + getCurrentSlaveCount()
-             + " / " + getRegisteredSlaveCount() + " slaves online.\nOffline slaves: [" + slavesListString + "]";
+             + " / " + getRegisteredSlaveCount() + "] slaves online.\nOffline slaves: [" + slavesListString + "]";
    }
 }


### PR DESCRIPTION
New exceptions: SlavesNotConfiguredException, SlavesOfflineException

These are now thrown when either there are one or more unconfigured slaves or offline slaves. The output is more verbose so you know which slaves are unconfigured or offline.