### PR TITLE
Feat: close context on shutdown

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 ihmc {
    group = "us.ihmc"
-   version = "0.15.0"
+   version = "0.15.1-onex.1"
    vcsUrl = "https://github.com/ihmcrobotics/ihmc-ethercat-master"
    openSource = true
 

--- a/src/main/java/us/ihmc/etherCAT/master/EtherCATStateMachine.java
+++ b/src/main/java/us/ihmc/etherCAT/master/EtherCATStateMachine.java
@@ -122,6 +122,7 @@ class EtherCATStateMachine
          subdevices[i].cleanup();
       }
 
+      soem.ecx_close(master.getContext());
    }
 
 }

--- a/src/main/java/us/ihmc/etherCAT/master/EtherCATStateMachine.java
+++ b/src/main/java/us/ihmc/etherCAT/master/EtherCATStateMachine.java
@@ -9,11 +9,10 @@ import us.ihmc.soem.generated.soem;
 
 /**
  * Statemachine to do the state control for EtherCAT slaves.
- * 
- * This will configure the slaves to go in OP when the master reached stable execution as well as deal with slaves that got into an error mode
- * 
- * @author Jesper Smith
  *
+ * This will configure the slaves to go in OP when the master reached stable execution as well as deal with slaves that got into an error mode
+ *
+ * @author Jesper Smith
  */
 class EtherCATStateMachine
 {
@@ -64,7 +63,6 @@ class EtherCATStateMachine
 
    /**
     * State to wait for the master to attain a stable, minimal jitter rate.
-    *
     */
    private class WaitForMasterState implements LightWeightPipelineTask
    {
@@ -121,8 +119,5 @@ class EtherCATStateMachine
       {
          subdevices[i].cleanup();
       }
-
-      soem.ecx_close(master.getContext());
    }
-
 }

--- a/src/main/java/us/ihmc/etherCAT/master/Master.java
+++ b/src/main/java/us/ihmc/etherCAT/master/Master.java
@@ -547,6 +547,10 @@ public class Master implements MasterInterface
       
       getEtherCATStatusCallback().trace(TRACE_EVENT.STOP_HOUSEHOLDER);
       etherCATStateMachine.shutDown();
+
+      soem.ecx_close(context);
+      soem.ecx_destroy_context(context);
+      initialized = false;
    }
    
    /**

--- a/src/main/java/us/ihmc/etherCAT/master/Master.java
+++ b/src/main/java/us/ihmc/etherCAT/master/Master.java
@@ -549,7 +549,6 @@ public class Master implements MasterInterface
       etherCATStateMachine.shutDown();
 
       soem.ecx_close(context);
-      soem.ecx_destroy_context(context);
       initialized = false;
    }
    


### PR DESCRIPTION
<!-- What's in this pull request? -->
Closes the ethercat context upon state machine shutdown. Solves the issue where you cannot spawn multiple EtherCATRealtimeThreads in succession due to the context not being closed inbetween. 
